### PR TITLE
Polish dreaming and proposal web UX

### DIFF
--- a/src/adapters/web/validation/requests.ts
+++ b/src/adapters/web/validation/requests.ts
@@ -210,6 +210,7 @@ export function parseProposalBacklogQuery(params: URLSearchParams): WebProposalB
   const issues: ValidationIssue[] = [];
   const includeIneligible = params.get("includeIneligible");
   const query: WebProposalBacklogQuery = {
+    state: "open",
     ...readIntParam(params, "limit", issues, (value) => ({ limit: value })),
     ...readNumberParam(params, "minConfidence", issues, (value) => ({ minConfidence: value })),
     ...readStringParam(params, "createdSince", (value) => ({ createdSince: value })),

--- a/src/app/memory/trace-timeline.ts
+++ b/src/app/memory/trace-timeline.ts
@@ -34,14 +34,16 @@ export function buildDurableTraceTimeline(input: {
   recallEvents: DurableRecallEvent[];
   profileSnapshots: DurableTraceProfileSnapshot[];
 }): DurableTraceTimelineEvent[] {
-  const events: DurableTraceTimelineEvent[] = [
-    {
+  const events: DurableTraceTimelineEvent[] = [];
+
+  if (!isDreamCreatedDurable(input.durable, input.dreamActions)) {
+    events.push({
       at: input.durable.created_at,
       kind: "created",
       label: "Durable created",
       detail: formatProvenanceDetail(input.durable),
-    },
-  ];
+    });
+  }
 
   const createdMs = Date.parse(input.durable.created_at);
   const updatedMs = Date.parse(input.durable.updated_at);
@@ -49,7 +51,7 @@ export function buildDurableTraceTimeline(input: {
     events.push({
       at: input.durable.updated_at,
       kind: "updated",
-      label: "Durable updated",
+      label: input.durable.superseded_by ? "Marked superseded" : "Durable updated",
       detail: formatUpdateDetail(input.durable),
     });
   }
@@ -58,8 +60,8 @@ export function buildDurableTraceTimeline(input: {
     events.push({
       at: action.createdAt,
       kind: "dream",
-      label: `Dream ${action.actionType}`,
-      detail: action.reasoning,
+      label: formatDreamActionLabel(action.actionType),
+      detail: formatDreamActionDetail(action),
       runId: action.runId,
       actionType: action.actionType,
     });
@@ -69,7 +71,7 @@ export function buildDurableTraceTimeline(input: {
     events.push({
       at: snapshot.createdAt,
       kind: "profile",
-      label: snapshot.role === "directive" ? "Included in directive profile snapshot" : "Included in profile snapshot",
+      label: snapshot.role === "directive" ? "Selected for directive startup profile" : "Selected for startup memory profile",
       detail: `snapshot=${snapshot.id}`,
       runId: snapshot.runId ?? undefined,
     });
@@ -85,6 +87,95 @@ export function buildDurableTraceTimeline(input: {
   }
 
   return events.sort(compareTimelineEvents);
+}
+
+/** Returns whether a Dreaming audit action is already the durable creation event. */
+function isDreamCreatedDurable(durable: Durable, dreamActions: DurableTraceDreamAction[]): boolean {
+  return dreamActions.some((action) => {
+    if (action.actionType !== "insert_durable" && action.actionType !== "supersede_durable") {
+      return false;
+    }
+    return action.createdAt === durable.created_at;
+  });
+}
+
+/** Formats a Dreaming audit action into an operator-facing timeline label. */
+function formatDreamActionLabel(actionType: string): string {
+  switch (actionType) {
+    case "insert_durable":
+      return "Dreaming extracted durable";
+    case "supersede_durable":
+      return "Dreaming created revision";
+    case "stale":
+      return "Dreaming marked stale";
+    case "update_durable":
+      return "Dreaming updated durable";
+    case "merge":
+      return "Dreaming merged durable";
+    case "log_conflict":
+      return "Dreaming logged conflict";
+    case "resolve_conflict":
+      return "Dreaming resolved conflict";
+    case "flag_review":
+      return "Dreaming flagged review";
+    case "skip":
+      return "Dreaming skipped action";
+    default:
+      return `Dreaming ${actionType}`;
+  }
+}
+
+/** Formats Dreaming audit details without relying on raw action identifiers. */
+function formatDreamActionDetail(action: DurableTraceDreamAction): string | undefined {
+  const parts: string[] = [];
+  if (action.reasoning) {
+    parts.push(action.reasoning);
+  }
+  if (action.details) {
+    const claimKey = readDetailString(action.details, "claim_key");
+    if (claimKey) {
+      parts.push(`claim_key=${claimKey}`);
+    }
+
+    const evidenceRefs = readDetailStringArray(action.details, "evidence_refs");
+    if (evidenceRefs.length > 0) {
+      parts.push(`evidence=${evidenceRefs.join(", ")}`);
+    }
+
+    const predecessorId = readDetailString(action.details, "predecessor_id");
+    if (predecessorId) {
+      parts.push(`predecessor=${predecessorId}`);
+    }
+
+    const successorId = readDetailString(action.details, "successor_id");
+    if (successorId) {
+      parts.push(`successor=${successorId}`);
+    }
+
+    const validTo = readDetailString(action.details, "valid_to");
+    if (validTo) {
+      parts.push(`valid_to=${validTo}`);
+    }
+  }
+  if (action.runId) {
+    parts.push(`run=${action.runId}`);
+  }
+  return parts.length > 0 ? parts.join(" | ") : undefined;
+}
+
+/** Reads one optional string field from Dreaming action details. */
+function readDetailString(details: Record<string, unknown>, key: string): string | undefined {
+  const value = details[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+/** Reads one optional string array field from Dreaming action details. */
+function readDetailStringArray(details: Record<string, unknown>, key: string): string[] {
+  const value = details[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
 }
 
 /** Formats provenance detail for a created timeline event. */

--- a/src/app/web/proposal-service.ts
+++ b/src/app/web/proposal-service.ts
@@ -29,7 +29,7 @@ export interface WebProposalDetail {
 export async function loadWebProposalBacklog(
   input: WebProposalBacklogQuery & { context: WebInstanceContext; env?: NodeJS.ProcessEnv },
 ): Promise<DreamProposalBacklogItem[]> {
-  return loadDreamBacklogRuntime({ ...input, dbPath: input.context.dbPath });
+  return loadDreamBacklogRuntime({ ...input, state: input.state ?? "open", dbPath: input.context.dbPath });
 }
 
 /**

--- a/tests/adapters/web/validation/requests.test.ts
+++ b/tests/adapters/web/validation/requests.test.ts
@@ -5,6 +5,7 @@ import type { ValidationIssue } from "../../../../src/adapters/shared/validation
 import {
   parseDreamStartBody,
   parseDurableListQuery,
+  parseProposalBacklogQuery,
   parseProcedureSaveBody,
   parseProcedureValidateBody,
   parseRegisterInstanceBody,
@@ -154,6 +155,21 @@ describe("parseReviewBody", () => {
   it("rejects an unknown decision", () => {
     const issues = captureIssues(() => parseReviewBody({ decision: "maybe", reason: "later" }));
     expect(paths(issues)).toContain("decision");
+  });
+});
+
+describe("parseProposalBacklogQuery", () => {
+  it("defaults the proposal backlog to open eligible proposals", () => {
+    expect(parseProposalBacklogQuery(new URLSearchParams())).toEqual({
+      state: "open",
+      eligibleOnly: true,
+    });
+  });
+
+  it("keeps handled proposals out when showing all open eligibility states", () => {
+    expect(parseProposalBacklogQuery(new URLSearchParams("includeIneligible=true"))).toEqual({
+      state: "open",
+    });
   });
 });
 

--- a/tests/app/memory/render-trace.test.ts
+++ b/tests/app/memory/render-trace.test.ts
@@ -15,7 +15,7 @@ describe("renderDurableTrace", () => {
     expect(output).toContain("claim_family=jim/dog");
     expect(output).toContain("[recall] total=3 showing=1");
     expect(output).toContain("[timeline]");
-    expect(output).toContain("Dream stale");
+    expect(output).toContain("Dreaming marked stale");
   });
 
   it("renders structured JSON with audit fields", () => {
@@ -101,7 +101,7 @@ function createTrace(): DurableTrace {
       {
         at: "2026-06-06T03:30:00.000Z",
         kind: "dream",
-        label: "Dream stale",
+        label: "Dreaming marked stale",
         runId: "run-1",
         actionType: "stale",
       },

--- a/tests/app/memory/trace-timeline.test.ts
+++ b/tests/app/memory/trace-timeline.test.ts
@@ -9,6 +9,7 @@ describe("buildDurableTraceTimeline", () => {
       created_at: "2026-06-06T02:00:00.000Z",
       updated_at: "2026-06-06T03:30:00.000Z",
       source_file: "episode:abc",
+      superseded_by: "entry-2",
       supersession_reason: "Dream prune staled a low-signal durable after synthesis.",
       valid_to: "2026-06-06T03:30:00.000Z",
     });
@@ -44,8 +45,44 @@ describe("buildDurableTraceTimeline", () => {
     });
 
     expect(timeline.map((event) => event.kind)).toEqual(["created", "dream", "profile", "updated", "dream", "recall"]);
-    expect(timeline[1]?.label).toBe("Dream insert_durable");
+    expect(timeline[1]?.label).toBe("Dreaming extracted durable");
+    expect(timeline[2]?.label).toBe("Selected for startup memory profile");
+    expect(timeline[3]?.label).toBe("Marked superseded");
     expect(timeline[4]?.actionType).toBe("stale");
+  });
+
+  it("uses the Dreaming creation action as the creation event for dreamed durables", () => {
+    const entry = createEntry({
+      created_at: "2026-06-06T02:35:00.000Z",
+      updated_at: "2026-06-06T02:35:00.000Z",
+      source_file: "episode:abc",
+      claim_key_source: "dreaming_extract",
+    });
+
+    const timeline = buildDurableTraceTimeline({
+      durable: entry,
+      dreamActions: [
+        {
+          id: "action-1",
+          runId: "run-1",
+          actionType: "insert_durable",
+          reasoning: "Inserted durable mined from episode evidence.",
+          details: {
+            claim_key: "jim/dog",
+            evidence_refs: ["episode:abc"],
+          },
+          createdAt: "2026-06-06T02:35:00.000Z",
+        },
+      ],
+      recallEvents: [],
+      profileSnapshots: [],
+    });
+
+    expect(timeline.map((event) => event.label)).toEqual(["Dreaming extracted durable"]);
+    expect(timeline[0]?.detail).toContain("Inserted durable mined from episode evidence.");
+    expect(timeline[0]?.detail).toContain("claim_key=jim/dog");
+    expect(timeline[0]?.detail).toContain("evidence=episode:abc");
+    expect(timeline[0]?.detail).toContain("run=run-1");
   });
 });
 

--- a/tests/cli/commands/trace.test.ts
+++ b/tests/cli/commands/trace.test.ts
@@ -41,7 +41,7 @@ describe("registerTraceCommand", () => {
     expect(stdout.join("")).toContain("[lineage]");
     expect(stdout.join("")).toContain("claim_family=jim/home_city");
     expect(stdout.join("")).toContain("[timeline]");
-    expect(stdout.join("")).toContain("Dream stale");
+    expect(stdout.join("")).toContain("Dreaming marked stale");
   });
 
   it("renders structured JSON trace output when requested", async () => {
@@ -178,7 +178,7 @@ function createTrace() {
       {
         at: "2026-03-21T00:00:00.000Z",
         kind: "dream",
-        label: "Dream stale",
+        label: "Dreaming marked stale",
         runId: "run-1",
         actionType: "stale",
       },

--- a/web/src/components/durable/DurableMetadataForm.tsx
+++ b/web/src/components/durable/DurableMetadataForm.tsx
@@ -63,15 +63,15 @@ export function DurableMetadataForm({
   };
 
   return (
-    <div className="stack" style={{ gap: "var(--space-4)" }}>
+    <div className="metadata-form">
       <span className="section-title">Edit metadata</span>
-      <div className="row" style={{ gap: "var(--space-3)" }}>
-        <div className="grow">
+      <div className="metadata-form__grid">
+        <div className="metadata-form__field">
           <Field label="Importance" hint="0.0 - 1.0">
             <Input type="number" min="0" max="1" step="0.05" value={importance} onChange={(event) => setImportance(event.target.value)} />
           </Field>
         </div>
-        <div className="grow">
+        <div className="metadata-form__field">
           <Field label="Expiry">
             <Select value={expiry} onChange={(event) => setExpiry(event.target.value)}>
               {EXPIRY_LEVELS.map((level) => (
@@ -82,23 +82,23 @@ export function DurableMetadataForm({
             </Select>
           </Field>
         </div>
-      </div>
-      <Field label="Claim key" hint="Changing this writes a trusted manual lifecycle bundle.">
-        <Input value={claimKey} onChange={(event) => setClaimKey(event.target.value)} placeholder="entity/attribute" />
-      </Field>
-      <div className="row" style={{ gap: "var(--space-3)" }}>
-        <div className="grow">
+        <div className="metadata-form__field metadata-form__field--wide">
+          <Field label="Claim key" hint="Changing this writes a trusted manual lifecycle bundle.">
+            <Input value={claimKey} onChange={(event) => setClaimKey(event.target.value)} placeholder="entity/attribute" />
+          </Field>
+        </div>
+        <div className="metadata-form__field">
           <Field label="Project">
             <Input value={project} onChange={(event) => setProject(event.target.value)} />
           </Field>
         </div>
-        <div className="grow">
+        <div className="metadata-form__field">
           <Field label="Valid to" hint="Sets the historical cutoff">
             <Input type="date" value={validTo} onChange={(event) => setValidTo(event.target.value)} />
           </Field>
         </div>
       </div>
-      <div className="row" style={{ gap: "var(--space-2)", justifyContent: "flex-end" }}>
+      <div className="metadata-form__actions">
         <Button variant="ghost" onClick={onCancel}>
           Cancel
         </Button>

--- a/web/src/components/durable/DurableTraceView.tsx
+++ b/web/src/components/durable/DurableTraceView.tsx
@@ -1,5 +1,5 @@
 import type { Durable, DurableTrace } from "../../api/types";
-import { formatDateTime, formatRelative, titleCase } from "../../lib/format";
+import { formatDateTime, formatDateTimeSeconds, formatRelative, titleCase } from "../../lib/format";
 import { claimStatusVariant, durableState, durableStateVariant } from "../../lib/status";
 import { Badge, Chip, KeyValue, Tabs } from "../primitives";
 import { DurableRetireAction } from "./DurableRetireAction";
@@ -102,7 +102,10 @@ export function DurableTraceView({
                   <div className="stack" style={{ gap: 2 }}>
                     <div className="spread">
                       <strong style={{ fontSize: "var(--text-sm)" }}>{event.label}</strong>
-                      <span className="tl-time" title={formatDateTime(event.at)}>{formatRelative(event.at)}</span>
+                      <span className="tl-time" title={event.at}>
+                        <span className="tl-time__exact">{formatDateTimeSeconds(event.at)}</span>
+                        <span className="tl-time__relative">{formatRelative(event.at)}</span>
+                      </span>
                     </div>
                     {event.detail ? <span className="muted" style={{ fontSize: "var(--text-xs)" }}>{event.detail}</span> : null}
                   </div>

--- a/web/src/components/primitives.tsx
+++ b/web/src/components/primitives.tsx
@@ -185,6 +185,8 @@ export function KeyValue({ rows }: { rows: KeyValueRow[] }): React.ReactElement 
 interface ChipProps {
   children: ReactNode;
   mono?: boolean;
+  title?: string;
+  className?: string;
 }
 
 /**
@@ -193,8 +195,13 @@ interface ChipProps {
  * @param props - Chip content and a monospace flag.
  * @returns The rendered chip.
  */
-export function Chip({ children, mono }: ChipProps): React.ReactElement {
-  return <span className={`chip${mono ? " chip--mono" : ""}`}>{children}</span>;
+export function Chip({ children, mono, title, className }: ChipProps): React.ReactElement {
+  const classes = ["chip", mono ? "chip--mono" : "", className ?? ""].filter(Boolean).join(" ");
+  return (
+    <span className={classes} title={title}>
+      {children}
+    </span>
+  );
 }
 
 /** One tab definition. */

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -63,6 +63,30 @@ export function formatDateTime(iso: string | null | undefined): string {
 }
 
 /**
+ * Formats an ISO timestamp as a readable local date-time including seconds.
+ *
+ * @param iso - ISO timestamp string, or null.
+ * @returns Localized date-time with seconds, or an em-dash placeholder.
+ */
+export function formatDateTimeSeconds(iso: string | null | undefined): string {
+  if (!iso) {
+    return "-";
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+/**
  * Formats an ISO timestamp as local date-time with compact relative context.
  *
  * @param iso - ISO timestamp string, or null.

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -63,6 +63,21 @@ export function formatDateTime(iso: string | null | undefined): string {
 }
 
 /**
+ * Formats an ISO timestamp as local date-time with compact relative context.
+ *
+ * @param iso - ISO timestamp string, or null.
+ * @returns Localized date-time plus relative age when available.
+ */
+export function formatDateTimeWithRelative(iso: string | null | undefined): string {
+  const dateTime = formatDateTime(iso);
+  const relative = formatRelative(iso);
+  if (dateTime === "-" || relative === "-") {
+    return dateTime;
+  }
+  return `${dateTime} (${relative})`;
+}
+
+/**
  * Formats a number with grouped thousands.
  *
  * @param value - Numeric value.

--- a/web/src/pages/DreamingPage.tsx
+++ b/web/src/pages/DreamingPage.tsx
@@ -10,7 +10,7 @@ import { useAsync } from "../hooks/useAsync";
 import { useDreamStream } from "../hooks/useDreamStream";
 import { useInstances } from "../state/InstanceContext";
 import { describeEvent } from "../lib/dream-progress";
-import { formatCost, formatDateTime, formatRelative, titleCase } from "../lib/format";
+import { formatCost, formatDateTime, formatDateTimeWithRelative, formatRelative, titleCase } from "../lib/format";
 import { jobStatusVariant, runStatusVariant } from "../lib/status";
 
 /** Available dreaming tiers with descriptions. */
@@ -19,6 +19,21 @@ const TIERS: { id: "light" | "standard" | "deep"; label: string; hint: string }[
   { id: "standard", label: "Standard", hint: "Reconcile + project profile" },
   { id: "deep", label: "Deep", hint: "Full extract and synthesis" },
 ];
+
+/** UUID text emitted by storage-level audit payloads. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+/** UUID fragments embedded inside storage-level audit prose. */
+const UUID_IN_TEXT_PATTERN = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/giu;
+
+/** Detail field labels for operator-facing dream action payloads. */
+const DETAIL_KEY_LABELS: Record<string, string> = {
+  claim_key: "Claim key",
+  evidence_refs: "Evidence",
+  predecessor_id: "Previous durable",
+  successor_id: "Replacement durable",
+  valid_to: "Valid until",
+};
 
 /**
  * Dreaming Runs page: launch maintenance runs and monitor live progress.
@@ -263,10 +278,10 @@ function RunDetailDrawer({ run, onClose }: { run: DreamRunRecord; onClose: () =>
       title={
         <span className="row" style={{ gap: "var(--space-2)" }}>
           <StatusDot status={runStatusVariant(run.status)} />
-          {titleCase(run.tier)} run
+          {titleCase(run.tier)} {run.dryRun ? "dry run" : "applied run"}
         </span>
       }
-      subtitle={<span className="mono">{run.id}</span>}
+      subtitle={<span>{formatDateTimeWithRelative(run.startedAt)}</span>}
       onClose={onClose}
     >
       <div className="stack" style={{ gap: "var(--space-5)" }}>
@@ -293,18 +308,23 @@ function RunDetailDrawer({ run, onClose }: { run: DreamRunRecord; onClose: () =>
             <Skeleton height={60} />
           ) : actions.data && actions.data.actions.length > 0 ? (
             <div className="stack" style={{ gap: "var(--space-2)" }}>
-              {actions.data.actions.map((action) => (
-                <div key={action.id} className="card" style={{ padding: "var(--space-3)" }}>
-                  <div className="spread">
-                    <Badge status="dream">{titleCase(action.actionType)}</Badge>
-                    <span className="muted" style={{ fontSize: "var(--text-xs)" }}>{formatRelative(action.createdAt)}</span>
+              {actions.data.actions.map((action) => {
+                const durableById = new Map(action.durables.map((durable) => [durable.id, durable]));
+                return (
+                  <div key={action.id} className="card" style={{ padding: "var(--space-3)" }}>
+                    <div className="spread">
+                      <Badge status="dream">{titleCase(action.actionType)}</Badge>
+                      <span className="muted" style={{ fontSize: "var(--text-xs)" }} title={formatDateTimeWithRelative(action.createdAt)}>
+                        {formatDateTime(action.createdAt)}
+                      </span>
+                    </div>
+                    <p className="secondary" style={{ fontSize: "var(--text-sm)", marginTop: "var(--space-2)" }} title={action.reasoning}>
+                      {formatActionReasoning(action.reasoning, action.details, durableById)}
+                    </p>
+                    <DreamActionChangeSummary action={action} />
                   </div>
-                  <p className="secondary" style={{ fontSize: "var(--text-sm)", marginTop: "var(--space-2)" }}>
-                    {action.reasoning}
-                  </p>
-                  <DreamActionChangeSummary action={action} />
-                </div>
-              ))}
+                );
+              })}
             </div>
           ) : (
             <span className="muted" style={{ fontSize: "var(--text-sm)" }}>No actions were recorded for this run.</span>
@@ -343,26 +363,37 @@ function RunDetailDrawer({ run, onClose }: { run: DreamRunRecord; onClose: () =>
 /** Renders the concrete change payload for one dream action. */
 function DreamActionChangeSummary({ action }: { action: DreamRunActionView }): React.ReactElement {
   const details = action.details ? Object.entries(action.details).filter(([, value]) => value !== null && value !== undefined && value !== "") : [];
+  const durableById = new Map(action.durables.map((durable) => [durable.id, durable]));
 
   return (
     <div className="stack" style={{ gap: "var(--space-2)", marginTop: "var(--space-3)" }}>
       {action.durableIds.length > 0 ? (
         <div className="row wrap" style={{ gap: "var(--space-2)" }}>
           <span className="muted" style={{ fontSize: "var(--text-xs)" }}>Affected</span>
-          {action.durableIds.map((durableId) => (
-            <Chip key={durableId} mono>{durableId}</Chip>
-          ))}
+          {action.durableIds.map((durableId) => {
+            const label = formatAffectedDurableReference(durableId, action.details, durableById);
+            return (
+              <Chip key={durableId} className="chip--compact" title={formatAffectedDurableReferenceTitle(durableId, action.details, durableById)}>
+                <span className="truncate">{label}</span>
+              </Chip>
+            );
+          })}
         </div>
       ) : null}
 
       {details.length > 0 ? (
         <div className="change-grid">
-          {details.map(([key, value]) => (
-            <div key={key} style={{ display: "contents" }}>
-              <span className="change-grid__key">{formatDetailKey(key)}</span>
-              <span className="change-grid__value">{formatDetailValue(value)}</span>
-            </div>
-          ))}
+          {details.map(([key, value]) => {
+            const formatted = formatDetailValue(value, key, durableById);
+            return (
+              <div key={key} style={{ display: "contents" }}>
+                <span className="change-grid__key">{formatDetailKey(key)}</span>
+                <span className="change-grid__value truncate" title={formatted.title}>
+                  {formatted.label}
+                </span>
+              </div>
+            );
+          })}
         </div>
       ) : null}
 
@@ -371,10 +402,14 @@ function DreamActionChangeSummary({ action }: { action: DreamRunActionView }): R
           {action.durables.map((durable) => (
             <div key={durable.id} className="change-item">
               <div className="spread" style={{ gap: "var(--space-2)" }}>
-                <strong className="truncate" style={{ fontSize: "var(--text-xs)" }}>{durable.subject}</strong>
-                {durable.claim_key ? <span className="mono muted" style={{ fontSize: "var(--text-2xs)" }}>{durable.claim_key}</span> : null}
+                <strong className="truncate" style={{ fontSize: "var(--text-xs)" }} title={durable.subject}>{durable.subject}</strong>
+                {durable.claim_key ? (
+                  <span className="mono muted truncate" style={{ fontSize: "var(--text-2xs)" }} title={durable.claim_key}>
+                    {durable.claim_key}
+                  </span>
+                ) : null}
               </div>
-              <span className="muted truncate" style={{ fontSize: "var(--text-xs)" }}>{durable.content}</span>
+              <span className="muted truncate" style={{ fontSize: "var(--text-xs)" }} title={durable.content}>{durable.content}</span>
             </div>
           ))}
         </div>
@@ -385,18 +420,158 @@ function DreamActionChangeSummary({ action }: { action: DreamRunActionView }): R
 
 /** Formats an action detail key for compact display. */
 function formatDetailKey(key: string): string {
-  return key.replaceAll("_", " ");
+  return DETAIL_KEY_LABELS[key] ?? titleCase(key.replaceAll("_", " "));
+}
+
+/** Operator-facing detail value with the raw value preserved for hover text. */
+interface FormattedDetailValue {
+  label: string;
+  title: string;
+}
+
+/** Formats a durable reference as a stable operator-facing label. */
+function formatDurableReference(durableId: string, durableById: Map<string, DreamRunActionView["durables"][number]>): string {
+  const durable = durableById.get(durableId);
+  if (!durable) {
+    return "Missing durable";
+  }
+  if (durable.claim_key) {
+    return `${durable.subject} - ${durable.claim_key}`;
+  }
+  return durable.subject;
+}
+
+/** Formats an affected durable list item without exposing storage IDs. */
+function formatAffectedDurableReference(
+  durableId: string,
+  details: Record<string, unknown> | null,
+  durableById: Map<string, DreamRunActionView["durables"][number]>,
+): string {
+  const durable = durableById.get(durableId);
+  if (durable) {
+    return formatDurableReference(durableId, durableById);
+  }
+  return formatMissingDurableLabel(durableId, details);
+}
+
+/** Builds full hover text for an affected durable chip. */
+function formatDurableReferenceTitle(durableId: string, durableById: Map<string, DreamRunActionView["durables"][number]>): string {
+  const durable = durableById.get(durableId);
+  if (!durable) {
+    return `Missing durable: ${durableId}`;
+  }
+  const parts = [`${durable.subject}`, durable.claim_key ? `Claim key: ${durable.claim_key}` : null, `Durable ID: ${durable.id}`];
+  return parts.filter((part): part is string => Boolean(part)).join("\n");
+}
+
+/** Builds hover text for an affected durable list item. */
+function formatAffectedDurableReferenceTitle(
+  durableId: string,
+  details: Record<string, unknown> | null,
+  durableById: Map<string, DreamRunActionView["durables"][number]>,
+): string {
+  const durable = durableById.get(durableId);
+  if (durable) {
+    return formatDurableReferenceTitle(durableId, durableById);
+  }
+  return `${formatMissingDurableLabel(durableId, details)}: ${durableId}`;
+}
+
+/** Replaces raw durable UUIDs in persisted action prose with friendly labels. */
+function formatActionReasoning(
+  reasoning: string,
+  details: Record<string, unknown> | null,
+  durableById: Map<string, DreamRunActionView["durables"][number]>,
+): string {
+  const predecessorId = typeof details?.predecessor_id === "string" ? details.predecessor_id : null;
+  const successorId = typeof details?.successor_id === "string" ? details.successor_id : null;
+  if (predecessorId && successorId && reasoning.startsWith("Superseded durable ")) {
+    const predecessor = formatSentenceReference(formatAffectedDurableReference(predecessorId, details, durableById));
+    const successor = formatSentenceReference(formatAffectedDurableReference(successorId, details, durableById));
+    return `Superseded ${predecessor} with temporal revision ${successor}.`;
+  }
+
+  return reasoning.replace(UUID_IN_TEXT_PATTERN, (durableId) => formatAffectedDurableReference(durableId, details, durableById));
+}
+
+/** Makes role labels read naturally inside generated prose. */
+function formatSentenceReference(label: string): string {
+  if (label === "Previous durable" || label === "Replacement durable" || label === "Missing durable") {
+    return `${label.charAt(0).toLowerCase()}${label.slice(1)}`;
+  }
+  return label;
+}
+
+/** Labels missing durable references by their role when action details expose it. */
+function formatMissingDurableLabel(durableId: string, details: Record<string, unknown> | null): string {
+  if (details?.predecessor_id === durableId) {
+    return "Previous durable";
+  }
+  if (details?.successor_id === durableId) {
+    return "Replacement durable";
+  }
+  return "Missing durable";
 }
 
 /** Formats a structured action detail value for compact display. */
-function formatDetailValue(value: unknown): string {
+function formatDetailValue(value: unknown, key: string, durableById: Map<string, DreamRunActionView["durables"][number]>): FormattedDetailValue {
   if (Array.isArray(value)) {
-    return value.map((entry) => formatDetailValue(entry)).join(", ");
+    const entries = value.map((entry) => formatDetailValue(entry, key, durableById));
+    return {
+      label: summarizeDetailList(entries, key),
+      title: entries.map((entry) => entry.title).join("\n"),
+    };
   }
 
   if (typeof value === "object" && value !== null) {
-    return JSON.stringify(value);
+    const raw = JSON.stringify(value);
+    return { label: raw, title: raw };
   }
 
-  return String(value);
+  const text = String(value);
+  const durable = durableById.get(text);
+  if (durable) {
+    return { label: formatDurableReference(text, durableById), title: formatDurableReferenceTitle(text, durableById) };
+  }
+  if (isTimestampDetail(key, text)) {
+    return { label: formatDateTime(text), title: text };
+  }
+  if (isEvidenceReference(text)) {
+    return { label: "Episode evidence", title: text };
+  }
+  if (UUID_PATTERN.test(text)) {
+    return { label: friendlyIdentifierLabel(key), title: text };
+  }
+  return { label: text, title: text };
+}
+
+/** Summarizes repeated action detail values without exposing raw storage IDs. */
+function summarizeDetailList(entries: FormattedDetailValue[], key: string): string {
+  if (entries.length === 0) {
+    return "-";
+  }
+  if (key === "evidence_refs") {
+    return entries.length === 1 ? entries[0]?.label ?? "Evidence" : `${entries.length} evidence refs`;
+  }
+  return entries.map((entry) => entry.label).join(", ");
+}
+
+/** Returns whether a detail value is an ISO timestamp field. */
+function isTimestampDetail(key: string, value: string): boolean {
+  if (!/(?:_at|_to|_from)$/u.test(key)) {
+    return false;
+  }
+  return Number.isFinite(Date.parse(value));
+}
+
+/** Returns whether a raw evidence reference contains an internal storage UUID. */
+function isEvidenceReference(value: string): boolean {
+  const [prefix, id] = value.split(":", 2);
+  return prefix === "episode" && id !== undefined && UUID_PATTERN.test(id);
+}
+
+/** Builds a generic friendly label for an internal identifier detail. */
+function friendlyIdentifierLabel(key: string): string {
+  const label = DETAIL_KEY_LABELS[key] ?? titleCase(key.replaceAll("_", " "));
+  return label.toLowerCase().includes("durable") ? label : `${label} record`;
 }

--- a/web/src/pages/DreamingPage.tsx
+++ b/web/src/pages/DreamingPage.tsx
@@ -419,11 +419,14 @@ function FlagReviewActionSummary({ action, onOpenProposals }: { action: DreamRun
 
       {action.durables.length > 0 ? <ActionDurableList action={action} /> : null}
 
-      <div className="row" style={{ justifyContent: "space-between", gap: "var(--space-3)" }}>
-        <details className="diagnostics">
+      {hasActionDetails(action) ? (
+        <details className="diagnostics review-summary__diagnostics">
           <summary>Diagnostics</summary>
           <ActionDetailsGrid action={action} />
         </details>
+      ) : null}
+
+      <div className="review-summary__actions">
         <Button variant="primary" size="sm" icon="arrow-right" onClick={onOpenProposals}>
           Open review
         </Button>

--- a/web/src/pages/DreamingPage.tsx
+++ b/web/src/pages/DreamingPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { ApiError, api } from "../api/client";
 import type { DreamJobSnapshot, DreamProposal, DreamRunActionView, DreamRunRecord, DreamRunsResponse } from "../api/types";
@@ -10,7 +11,7 @@ import { useAsync } from "../hooks/useAsync";
 import { useDreamStream } from "../hooks/useDreamStream";
 import { useInstances } from "../state/InstanceContext";
 import { describeEvent } from "../lib/dream-progress";
-import { formatCost, formatDateTime, formatDateTimeWithRelative, formatRelative, titleCase } from "../lib/format";
+import { formatCost, formatDateTime, formatDateTimeWithRelative, formatPercent, formatRelative, titleCase } from "../lib/format";
 import { jobStatusVariant, runStatusVariant } from "../lib/status";
 
 /** Available dreaming tiers with descriptions. */
@@ -270,6 +271,7 @@ function LiveRun({ job, onFinished }: { job: DreamJobSnapshot; onFinished: () =>
 
 /** Drawer showing a persisted run's actions and proposals. */
 function RunDetailDrawer({ run, onClose }: { run: DreamRunRecord; onClose: () => void }): React.ReactElement {
+  const navigate = useNavigate();
   const actions = useAsync(() => api.runActions(run.id), [run.id]);
   const proposals = useAsync(() => api.runProposals(run.id), [run.id]);
 
@@ -313,15 +315,21 @@ function RunDetailDrawer({ run, onClose }: { run: DreamRunRecord; onClose: () =>
                 return (
                   <div key={action.id} className="card" style={{ padding: "var(--space-3)" }}>
                     <div className="spread">
-                      <Badge status="dream">{titleCase(action.actionType)}</Badge>
+                      <Badge status={action.actionType === "flag_review" ? "warning" : "dream"}>{formatActionTypeLabel(action.actionType)}</Badge>
                       <span className="muted" style={{ fontSize: "var(--text-xs)" }} title={formatDateTimeWithRelative(action.createdAt)}>
                         {formatDateTime(action.createdAt)}
                       </span>
                     </div>
-                    <p className="secondary" style={{ fontSize: "var(--text-sm)", marginTop: "var(--space-2)" }} title={action.reasoning}>
-                      {formatActionReasoning(action.reasoning, action.details, durableById)}
-                    </p>
-                    <DreamActionChangeSummary action={action} />
+                    {action.actionType === "flag_review" ? (
+                      <FlagReviewActionSummary action={action} onOpenProposals={() => navigate("/proposals")} />
+                    ) : (
+                      <>
+                        <p className="secondary" style={{ fontSize: "var(--text-sm)", marginTop: "var(--space-2)" }} title={action.reasoning}>
+                          {formatActionReasoning(action.reasoning, action.details, durableById)}
+                        </p>
+                        <DreamActionChangeSummary action={action} />
+                      </>
+                    )}
                   </div>
                 );
               })}
@@ -360,9 +368,113 @@ function RunDetailDrawer({ run, onClose }: { run: DreamRunRecord; onClose: () =>
   );
 }
 
+/** Plain-language summary for a proposal staged for human review. */
+function FlagReviewActionSummary({ action, onOpenProposals }: { action: DreamRunActionView; onOpenProposals: () => void }): React.ReactElement {
+  const details = action.details ?? {};
+  const currentClaimKeys = readStringArrayDetail(details.current_claim_keys);
+  const proposedClaimKeys = readStringArrayDetail(details.proposed_claim_keys);
+  const confidence = typeof details.confidence === "number" ? details.confidence : null;
+  const eligibleForApply = details.eligible_for_apply === true;
+  const blocker = typeof details.auto_apply_blocker === "string" ? details.auto_apply_blocker : null;
+  const durableById = new Map(action.durables.map((durable) => [durable.id, durable]));
+
+  return (
+    <div className="review-summary">
+      <div className="review-summary__plain">
+        <strong>Dreaming found a suggested claim-key change.</strong>
+        <span>
+          Review means deciding whether the affected memory belongs under the proposed key. Apply writes that key after a backup; reject leaves the
+          memory unchanged and records the reason.
+        </span>
+      </div>
+
+      <div className="review-summary__grid">
+        <ReviewSummaryRow label="Current key" value={formatClaimKeyList(currentClaimKeys, "(no current key)")} />
+        <ReviewSummaryRow label="Proposed key" value={formatClaimKeyList(proposedClaimKeys, "(no proposed key)")} emphasized />
+        {confidence !== null ? <ReviewSummaryRow label="Confidence" value={formatPercent(confidence)} /> : null}
+        <ReviewSummaryRow label="Decision" value={formatReviewDecisionText(eligibleForApply, blocker)} />
+      </div>
+
+      <div className="stack" style={{ gap: "var(--space-2)" }}>
+        <span className="section-title">What to check</span>
+        <ul className="review-checklist">
+          <li>The memory text is really about the proposed topic.</li>
+          <li>The proposed key describes the stable slot this memory should be grouped under.</li>
+          <li>Applying the key would group it with the right related memories, not just similar wording.</li>
+        </ul>
+      </div>
+
+      <ReviewEvidenceSummary details={details} />
+
+      {action.durableIds.length > 0 ? (
+        <div className="row wrap" style={{ gap: "var(--space-2)" }}>
+          <span className="muted" style={{ fontSize: "var(--text-xs)" }}>Affected</span>
+          {action.durableIds.map((durableId) => (
+            <Chip key={durableId} className="chip--compact" title={formatAffectedDurableReferenceTitle(durableId, action.details, durableById)}>
+              <span className="truncate">{formatAffectedDurableReference(durableId, action.details, durableById)}</span>
+            </Chip>
+          ))}
+        </div>
+      ) : null}
+
+      {action.durables.length > 0 ? <ActionDurableList action={action} /> : null}
+
+      <div className="row" style={{ justifyContent: "space-between", gap: "var(--space-3)" }}>
+        <details className="diagnostics">
+          <summary>Diagnostics</summary>
+          <ActionDetailsGrid action={action} />
+        </details>
+        <Button variant="primary" size="sm" icon="arrow-right" onClick={onOpenProposals}>
+          Open review
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** One row in the staged-review summary. */
+function ReviewSummaryRow({ label, value, emphasized = false }: { label: string; value: string; emphasized?: boolean }): React.ReactElement {
+  return (
+    <div className="review-summary__row">
+      <span>{label}</span>
+      <strong className={emphasized ? "review-summary__value--emphasized" : undefined}>{value}</strong>
+    </div>
+  );
+}
+
+/** Plain-language evidence summary for review proposals. */
+function ReviewEvidenceSummary({ details }: { details: Record<string, unknown> }): React.ReactElement | null {
+  const familyReuseCount = readNumberDetail(details.support_family_reuse_count);
+  const groundedFamilyReuseCount = readNumberDetail(details.support_grounded_family_reuse_count);
+  const supportEvidence = readStringArrayDetail(details.support_evidence);
+  const hasSupportedCandidate = details.supported_candidate === true;
+
+  const lines = [
+    familyReuseCount > 0
+      ? `${familyReuseCount} related memor${familyReuseCount === 1 ? "y already uses" : "ies already use"} a compatible key.`
+      : null,
+    groundedFamilyReuseCount > 0
+      ? `${groundedFamilyReuseCount} of those related memories include supporting provenance.`
+      : null,
+    hasSupportedCandidate || supportEvidence.length > 0 ? "Dreaming found matching evidence in the existing corpus." : null,
+  ].filter((line): line is string => line !== null);
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="review-evidence">
+      <span className="section-title">Why it was suggested</span>
+      {lines.map((line) => (
+        <span key={line}>{line}</span>
+      ))}
+    </div>
+  );
+}
+
 /** Renders the concrete change payload for one dream action. */
 function DreamActionChangeSummary({ action }: { action: DreamRunActionView }): React.ReactElement {
-  const details = action.details ? Object.entries(action.details).filter(([, value]) => value !== null && value !== undefined && value !== "") : [];
   const durableById = new Map(action.durables.map((durable) => [durable.id, durable]));
 
   return (
@@ -381,41 +493,73 @@ function DreamActionChangeSummary({ action }: { action: DreamRunActionView }): R
         </div>
       ) : null}
 
-      {details.length > 0 ? (
-        <div className="change-grid">
-          {details.map(([key, value]) => {
-            const formatted = formatDetailValue(value, key, durableById);
-            return (
-              <div key={key} style={{ display: "contents" }}>
-                <span className="change-grid__key">{formatDetailKey(key)}</span>
-                <span className="change-grid__value truncate" title={formatted.title}>
-                  {formatted.label}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
+      {action.durables.length > 0 ? <ActionDurableList action={action} /> : null}
 
-      {action.durables.length > 0 ? (
-        <div className="stack" style={{ gap: "var(--space-2)" }}>
-          {action.durables.map((durable) => (
-            <div key={durable.id} className="change-item">
-              <div className="spread" style={{ gap: "var(--space-2)" }}>
-                <strong className="truncate" style={{ fontSize: "var(--text-xs)" }} title={durable.subject}>{durable.subject}</strong>
-                {durable.claim_key ? (
-                  <span className="mono muted truncate" style={{ fontSize: "var(--text-2xs)" }} title={durable.claim_key}>
-                    {durable.claim_key}
-                  </span>
-                ) : null}
-              </div>
-              <span className="muted truncate" style={{ fontSize: "var(--text-xs)" }} title={durable.content}>{durable.content}</span>
-            </div>
-          ))}
-        </div>
+      {hasActionDetails(action) ? (
+        <details className="diagnostics">
+          <summary>Diagnostics</summary>
+          <ActionDetailsGrid action={action} />
+        </details>
       ) : null}
     </div>
   );
+}
+
+/** Renders action detail fields as an audit grid. */
+function ActionDetailsGrid({ action }: { action: DreamRunActionView }): React.ReactElement | null {
+  const details = action.details ? Object.entries(action.details).filter(([, value]) => value !== null && value !== undefined && value !== "") : [];
+  const durableById = new Map(action.durables.map((durable) => [durable.id, durable]));
+
+  if (details.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="change-grid">
+      {details.map(([key, value]) => {
+        const formatted = formatDetailValue(value, key, durableById);
+        return (
+          <div key={key} style={{ display: "contents" }}>
+            <span className="change-grid__key">{formatDetailKey(key)}</span>
+            <span className="change-grid__value truncate" title={formatted.title}>
+              {formatted.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Returns whether an action has raw detail fields worth exposing in diagnostics. */
+function hasActionDetails(action: DreamRunActionView): boolean {
+  return action.details ? Object.values(action.details).some((value) => value !== null && value !== undefined && value !== "") : false;
+}
+
+/** Renders affected durable snippets for an action. */
+function ActionDurableList({ action }: { action: DreamRunActionView }): React.ReactElement {
+  return (
+    <div className="stack" style={{ gap: "var(--space-2)" }}>
+      {action.durables.map((durable) => (
+        <div key={durable.id} className="change-item">
+          <div className="spread" style={{ gap: "var(--space-2)" }}>
+            <strong className="truncate" style={{ fontSize: "var(--text-xs)" }} title={durable.subject}>{durable.subject}</strong>
+            {durable.claim_key ? (
+              <span className="mono muted truncate" style={{ fontSize: "var(--text-2xs)" }} title={durable.claim_key}>
+                {durable.claim_key}
+              </span>
+            ) : null}
+          </div>
+          <span className="muted truncate" style={{ fontSize: "var(--text-xs)" }} title={durable.content}>{durable.content}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Formats a dreaming action type for operator display. */
+function formatActionTypeLabel(actionType: string): string {
+  return actionType === "flag_review" ? "Needs review" : titleCase(actionType);
 }
 
 /** Formats an action detail key for compact display. */
@@ -574,4 +718,38 @@ function isEvidenceReference(value: string): boolean {
 function friendlyIdentifierLabel(key: string): string {
   const label = DETAIL_KEY_LABELS[key] ?? titleCase(key.replaceAll("_", " "));
   return label.toLowerCase().includes("durable") ? label : `${label} record`;
+}
+
+/** Reads a string array from an untyped action-detail payload. */
+function readStringArrayDetail(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0) : [];
+}
+
+/** Reads a number from an untyped action-detail payload. */
+function readNumberDetail(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/** Formats claim-key arrays for compact review summaries. */
+function formatClaimKeyList(values: string[], fallback: string): string {
+  return values.length > 0 ? values.join(", ") : fallback;
+}
+
+/** Describes the review action available for a proposal. */
+function formatReviewDecisionText(eligibleForApply: boolean, blocker: string | null): string {
+  if (eligibleForApply) {
+    return "Apply is available if the proposed key is correct.";
+  }
+  if (blocker) {
+    return `Reject or inspect manually. ${formatAutoApplyBlocker(blocker)}.`;
+  }
+  return "Reject or inspect manually. Apply is not available for this proposal.";
+}
+
+/** Formats a stored automatic-apply blocker without internal enum wording. */
+function formatAutoApplyBlocker(blocker: string): string {
+  if (blocker === "cross_type_collision") {
+    return "Another active memory already uses that key for a different type";
+  }
+  return `Automatic apply was blocked by ${titleCase(blocker.replaceAll("_", " ")).toLowerCase()}`;
 }

--- a/web/src/pages/ProposalsPage.tsx
+++ b/web/src/pages/ProposalsPage.tsx
@@ -42,7 +42,7 @@ function ProposalsInner(): React.ReactElement {
       <div className="page-head">
         <div className="page-head__lead">
           <h2>Proposal review</h2>
-          <p>Adjudicate claim-key proposals raised by dreaming. Applying mutates durables after a backup; both decisions require a reason.</p>
+          <p>Review suggested claim-key changes from dreaming. Apply writes the proposed key after a backup; reject leaves the memory unchanged.</p>
         </div>
         <Button variant="ghost" icon="refresh" onClick={state.refetch}>
           Refresh
@@ -112,7 +112,7 @@ function ProposalRow({ item, onOpen }: { item: ProposalBacklogItem; onOpen: () =
           <div className="stack" style={{ gap: "var(--space-3)", alignItems: "flex-end", flex: "none", width: 140 }}>
             <ConfidenceMeter value={proposal.confidence} />
             <Button variant="primary" size="sm" icon="arrow-right" onClick={onOpen}>
-              Review
+              Open review
             </Button>
           </div>
         </div>
@@ -211,6 +211,19 @@ function ProposalDrawer({ proposalId, onClose, onReviewed }: { proposalId: strin
             <Badge status="accent">{formatPercent(proposal.confidence)} confidence</Badge>
           </div>
 
+          <div className="review-brief">
+            <span className="section-title">Review decision</span>
+            <p>
+              Decide whether the affected memory should be grouped under the proposed claim key. Apply writes the proposed key after creating a
+              backup. Reject keeps the memory as it is and records why this suggestion should not be used.
+            </p>
+            <ul className="review-checklist">
+              <li>The memory text should be about the proposed topic.</li>
+              <li>The proposed key should describe the stable slot for this memory, not incidental wording.</li>
+              <li>The key should group this memory with the right related memories.</li>
+            </ul>
+          </div>
+
           <div className="stack" style={{ gap: "var(--space-2)" }}>
             <span className="section-title">Proposed change</span>
             <ClaimDiff current={proposal.currentClaimKeys} proposed={proposal.proposedClaimKeys} />
@@ -242,8 +255,8 @@ function ProposalDrawer({ proposalId, onClose, onReviewed }: { proposalId: strin
 
           {proposal.reviewStatus === "open" ? (
             <div className="stack" style={{ gap: "var(--space-3)" }}>
-              <Field label="Decision reason" hint="Recorded with the review for auditability.">
-                <Textarea rows={3} value={reason} placeholder="Why apply or reject this proposal?" onChange={(event) => setReason(event.target.value)} />
+              <Field label="Decision reason" hint="Explain why the proposed key should or should not be written.">
+                <Textarea rows={3} value={reason} placeholder="Why is this the right decision for this memory?" onChange={(event) => setReason(event.target.value)} />
               </Field>
               <div className="row" style={{ gap: "var(--space-3)", justifyContent: "flex-end" }}>
                 <Button variant="danger" icon="x" loading={busy === "reject"} onClick={() => void review("reject")}>

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -272,6 +272,16 @@
   color: var(--text-primary) !important;
 }
 
+.review-summary__diagnostics {
+  width: 100%;
+}
+
+.review-summary__actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--space-1);
+}
+
 .review-checklist {
   display: flex;
   flex-direction: column;
@@ -303,6 +313,17 @@
 
 .diagnostics .change-grid {
   margin-top: var(--space-2);
+  grid-template-columns: minmax(8.5rem, 34%) minmax(0, 1fr);
+}
+
+.diagnostics .change-grid__key {
+  overflow-wrap: anywhere;
+}
+
+.diagnostics .change-grid__value {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
 }
 
 .change-grid {

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -213,6 +213,98 @@
   min-width: 0;
 }
 
+.review-summary,
+.review-brief {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.review-summary__plain,
+.review-brief {
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-overlay);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.review-summary__plain {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.review-summary__plain strong,
+.review-brief .section-title {
+  color: var(--text-primary);
+}
+
+.review-summary__grid {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.review-summary__row {
+  display: grid;
+  grid-template-columns: minmax(92px, max-content) minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: baseline;
+  font-size: var(--text-xs);
+}
+
+.review-summary__row > span {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-size: var(--text-2xs);
+}
+
+.review-summary__row > strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-secondary);
+  font-weight: var(--weight-medium);
+}
+
+.review-summary__value--emphasized {
+  color: var(--text-primary) !important;
+}
+
+.review-checklist {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding-left: var(--space-5);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.review-evidence {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.diagnostics {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.diagnostics summary {
+  cursor: pointer;
+  width: max-content;
+}
+
+.diagnostics .change-grid {
+  margin-top: var(--space-2);
+}
+
 .change-grid {
   display: grid;
   grid-template-columns: minmax(96px, max-content) minmax(0, 1fr);

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -604,6 +604,44 @@
   color: var(--text-faint);
 }
 
+.metadata-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.metadata-form__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: var(--space-4) var(--space-3);
+}
+
+.metadata-form__field {
+  min-width: 0;
+}
+
+.metadata-form__field--wide {
+  grid-column: 1 / -1;
+}
+
+.metadata-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+@media (max-width: 640px) {
+  .metadata-form__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .metadata-form__actions {
+    flex-wrap: wrap;
+  }
+}
+
 /* ---------- Tabs & segmented ---------- */
 .tabs {
   display: flex;

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -189,6 +189,8 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
+  min-width: 0;
+  max-width: 100%;
   height: 26px;
   padding: 0 var(--space-3);
   border-radius: var(--radius-pill);
@@ -201,6 +203,14 @@
 .chip--mono {
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
+}
+
+.chip--compact {
+  max-width: min(100%, 280px);
+}
+
+.chip .truncate {
+  min-width: 0;
 }
 
 .change-grid {

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -409,9 +409,24 @@
 }
 
 .tl-time {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
   font-size: var(--text-2xs);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
+  line-height: 1.25;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.tl-time__exact {
+  color: var(--text-secondary);
+}
+
+.tl-time__relative {
+  color: var(--text-faint);
 }
 
 /* ---------- Diff / proposal ---------- */


### PR DESCRIPTION
## Summary
- Improves dreaming action labels, proposal review copy, diagnostics layout, backlog filtering, and durable metadata drawer UX.
- Operator-facing dreaming/proposal pages are clearer before backend dreaming changes land.

## Test plan
- [ ] `pnpm check`
- [ ] Review dreaming run detail drawer and proposal review drawer in the web console