### PR TITLE
Add mixed-key settlement and live dreaming feedback

### DIFF
--- a/docs/WEB-CONSOLE.md
+++ b/docs/WEB-CONSOLE.md
@@ -181,7 +181,7 @@ UI-initiated runs are coordinated in-process by `DreamingRunCoordinator`.
 
 - Ops Cockpit: composite corpus-health score, key metric tiles, claim-key lifecycle and recency distributions, proposal backlog and profile rollups, and recent run history with surfaced failures.
 - Dreaming Runs: launch light/standard/deep runs in dry-run or apply mode, watch a live progress feed, and inspect persisted run details, actions, and proposals.
-- Proposal Review: filterable backlog, a detail drawer with affected durables and current/proposed claim keys, and apply/reject with a required reason.
+- Proposal Review: filterable backlog, a detail drawer with affected durables and current/proposed claim keys, apply/reject with a required reason, and manual settlement choices for ambiguous mixed-key groups.
 - Memory Explorer: durable, episode, and procedure browsing with filters and pagination, a durable trace drawer, and lifecycle actions (store, supersede, update metadata, retire).
 - Procedure Editor: a YAML editor with debounced validation, a dirty-worktree banner, and save-and-sync that reports created/updated/unchanged results.
 - Instance Settings: register, select, and remove instances, with resolution diagnostics and a loopback-only security reminder.

--- a/tests/web/dream-progress.test.ts
+++ b/tests/web/dream-progress.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import type { DreamJobEvent } from "../../web/src/api/types.js";
+import { describeEvent } from "../../web/src/lib/dream-progress.js";
+
+type ReconcileProgress = Extract<NonNullable<DreamJobEvent["progress"]>, { kind: "reconcile_progress" }>;
+
+describe("dream progress log formatting", () => {
+  it("explains backup completion with the saved path", () => {
+    const line = describeEvent({
+      seq: 1,
+      at: "2026-06-08T16:00:00.000Z",
+      kind: "progress",
+      progress: {
+        kind: "phase",
+        phase: "backup_complete",
+        tier: "light",
+        apply: true,
+        backupPath: "/tmp/knowledge.db.backup",
+      },
+    });
+
+    expect(line).toEqual({
+      stage: "backup",
+      message: "Backup complete. Saved database copy to /tmp/knowledge.db.backup.",
+    });
+  });
+
+  it("summarizes loaded candidates and eligible proposals", () => {
+    const line = describeEvent({
+      seq: 2,
+      at: "2026-06-08T16:00:01.000Z",
+      kind: "progress",
+      progress: {
+        kind: "phase",
+        phase: "load_working_set_complete",
+        tier: "standard",
+        apply: false,
+        workingSetSize: 42,
+        eligibleProposalBacklogCount: 3,
+      },
+    });
+
+    expect(line).toEqual({
+      stage: "load",
+      message: "Loaded 42 candidate memories; 3 eligible proposals ready for resolution.",
+    });
+  });
+
+  it("renders reconcile counters and preview details", () => {
+    const line = describeEvent({
+      seq: 3,
+      at: "2026-06-08T16:00:02.000Z",
+      kind: "progress",
+      progress: {
+        kind: "reconcile_progress",
+        tier: "standard",
+        apply: true,
+        stage: "missing",
+        status: "preview_progress",
+        completed: 7,
+        total: 12,
+        unitLabel: "durables",
+        previewQueued: 4,
+        previewCompleted: 2,
+        previewTotal: 4,
+        previewConcurrency: 2,
+        processedDurables: 7,
+        totalDurables: 12,
+        elapsedMs: 1200,
+        counts: buildCounts({
+          appliedBackfills: 1,
+          proposalsEmitted: 2,
+          flaggedAmbiguousProposals: 1,
+          skippedLowConfidence: 3,
+        }),
+      },
+    });
+
+    expect(line).toEqual({
+      stage: "reconcile",
+      message: "Missing claim keys: Previewing 7/12 durables; 4 queued for LLM preview; 2/4 previews completed; 1 applied, 3 proposed, 3 skipped.",
+    });
+  });
+
+  it("renders proposal resolution outcomes", () => {
+    const line = describeEvent({
+      seq: 4,
+      at: "2026-06-08T16:00:03.000Z",
+      kind: "progress",
+      progress: {
+        kind: "proposal_resolution_progress",
+        tier: "proposal_resolution",
+        apply: true,
+        status: "proposal_processed",
+        totalProposals: 5,
+        processedProposals: 4,
+        appliedCount: 2,
+        rejectedInactiveCount: 1,
+        rejectedInvalidCount: 1,
+        noChangeCount: 0,
+        targetedEntryCount: 5,
+        issueKind: "missing_claim_key",
+        outcome: "applied",
+      },
+    });
+
+    expect(line).toEqual({
+      stage: "proposals",
+      message: "Processed 4/5 proposals; 2 applied; 1 inactive; 1 invalid; 0 unchanged; current issue Missing Claim Key; last outcome Applied.",
+    });
+  });
+
+  it("renders terminal status events", () => {
+    const line = describeEvent({
+      seq: 5,
+      at: "2026-06-08T16:00:04.000Z",
+      kind: "status",
+      status: "completed",
+      message: "Run run-1 completed.",
+    });
+
+    expect(line).toEqual({
+      stage: "complete",
+      message: "Run run-1 completed.",
+    });
+  });
+});
+
+function buildCounts(overrides: Partial<ReconcileProgress["counts"]> = {}): ReconcileProgress["counts"] {
+  return {
+    identifiedNormalizations: 0,
+    appliedNormalizations: 0,
+    identifiedBackfills: 0,
+    appliedBackfills: 0,
+    identifiedMetadataRewrites: 0,
+    appliedMetadataRewrites: 0,
+    identifiedEntityFamilyConvergences: 0,
+    appliedEntityFamilyConvergences: 0,
+    proposalsEmitted: 0,
+    skippedNoClaim: 0,
+    skippedLowConfidence: 0,
+    skippedCollision: 0,
+    flaggedAmbiguousProposals: 0,
+    ...overrides,
+  };
+}

--- a/web/src/lib/dream-progress.ts
+++ b/web/src/lib/dream-progress.ts
@@ -1,6 +1,11 @@
 import type { DreamJobEvent } from "../api/types";
 import { titleCase } from "./format";
 
+type DreamProgress = NonNullable<DreamJobEvent["progress"]>;
+type DreamPhaseProgress = Extract<DreamProgress, { kind: "phase" }>;
+type ReconcileProgress = Extract<DreamProgress, { kind: "reconcile_progress" }>;
+type ProposalResolutionProgress = Extract<DreamProgress, { kind: "proposal_resolution_progress" }>;
+
 /** A human-readable stage label and message for one job event. */
 export interface ProgressLine {
   /** Short stage label shown in the feed gutter. */
@@ -21,50 +26,199 @@ export interface ProgressLine {
  */
 export function describeEvent(event: DreamJobEvent): ProgressLine {
   if (event.kind === "status") {
-    return { stage: "status", message: event.message ?? titleCase(event.status ?? "update") };
+    return describeStatusEvent(event);
   }
 
-  const progress = toRecord(event.progress);
-  const kind = typeof progress.kind === "string" ? progress.kind : "progress";
-
-  if (kind === "phase") {
-    const phase = typeof progress.phase === "string" ? progress.phase : "phase";
-    const extras: string[] = [];
-    if (typeof progress.workingSetSize === "number") {
-      extras.push(`working set ${progress.workingSetSize}`);
-    }
-    if (typeof progress.backupPath === "string") {
-      extras.push("backup saved");
-    }
-    return { stage: "phase", message: `${titleCase(phase)}${extras.length > 0 ? ` \u00b7 ${extras.join(", ")}` : ""}` };
+  const progress = event.progress;
+  if (!progress) {
+    return { stage: "progress", message: "Received a progress update." };
   }
 
-  if (kind === "reconcile_progress") {
-    const stage = typeof progress.stage === "string" ? progress.stage : "reconcile";
-    const status = typeof progress.status === "string" ? progress.status : "";
-    const completed = numberOr(progress.completed, 0);
-    const total = numberOr(progress.total, 0);
-    const unit = typeof progress.unitLabel === "string" ? progress.unitLabel : "";
-    return { stage: `reconcile`, message: `${titleCase(stage)} \u00b7 ${status} ${completed}/${total} ${unit}`.trim() };
+  if (progress.kind === "phase") {
+    return describePhaseEvent(progress);
   }
 
-  if (kind === "proposal_resolution_progress") {
-    const status = typeof progress.status === "string" ? progress.status : "";
-    const processed = numberOr(progress.processedProposals, 0);
-    const total = numberOr(progress.totalProposals, 0);
-    const applied = numberOr(progress.appliedCount, 0);
-    return { stage: "proposals", message: `${titleCase(status)} \u00b7 ${processed}/${total} processed, ${applied} applied` };
+  if (progress.kind === "reconcile_progress") {
+    return describeReconcileEvent(progress);
   }
 
-  return { stage: kind, message: typeof progress.message === "string" ? progress.message : JSON.stringify(progress) };
+  if (progress.kind === "proposal_resolution_progress") {
+    return describeProposalResolutionEvent(progress);
+  }
+
+  return { stage: "progress", message: JSON.stringify(progress) };
 }
 
-/** Coerces an unknown value to a number with a fallback. */
-function numberOr(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+/** Formats terminal job status events for the live feed. */
+function describeStatusEvent(event: DreamJobEvent): ProgressLine {
+  switch (event.status) {
+    case "running":
+      return { stage: "status", message: event.message ?? "Run is active." };
+    case "completed":
+      return { stage: "complete", message: event.message ?? "Run completed and history is refreshing." };
+    case "failed":
+      return { stage: "failed", message: event.message ?? "Run failed. Open the run details for the recorded error." };
+    case "aborted":
+      return { stage: "cancelled", message: event.message ?? "Run was cancelled by the operator." };
+    default:
+      return { stage: "status", message: event.message ?? "Received a status update." };
+  }
 }
 
-/** Converts a structured progress union into a generic display record. */
-function toRecord(value: DreamJobEvent["progress"]): Record<string, unknown> {
-  return value ? Object.fromEntries(Object.entries(value)) : {};
+/** Formats high-level run phase events for the live feed. */
+function describePhaseEvent(progress: DreamPhaseProgress): ProgressLine {
+  const mode = progress.apply ? "apply" : "dry-run";
+  const tier = titleCase(progress.tier);
+
+  switch (progress.phase) {
+    case "start":
+      return { stage: "start", message: `Created ${tier} ${mode} run and initialized progress tracking.` };
+    case "backup_start":
+      return { stage: "backup", message: "Creating a database backup before applying corpus changes." };
+    case "backup_complete":
+      return {
+        stage: "backup",
+        message: progress.backupPath ? `Backup complete. Saved database copy to ${progress.backupPath}.` : "Backup complete.",
+      };
+    case "load_working_set_start":
+      return { stage: "load", message: "Loading candidate memories and proposal backlog for this run." };
+    case "load_working_set_complete": {
+      const parts = [`Loaded ${formatCount(progress.workingSetSize, "candidate memory", "candidate memories")}`];
+      if (typeof progress.eligibleProposalBacklogCount === "number") {
+        parts.push(`${formatCount(progress.eligibleProposalBacklogCount, "eligible proposal", "eligible proposals")} ready for resolution`);
+      }
+      return { stage: "load", message: `${parts.join("; ")}.` };
+    }
+    case "load_pass_context_start":
+      return { stage: "context", message: "Loading claim-key health, trusted families, and pass context." };
+    case "load_pass_context_complete":
+      return { stage: "context", message: "Pass context loaded." };
+    case "pass_start":
+      return { stage: "pass", message: `Starting the ${tier} reconcile pass in ${mode} mode.` };
+    default:
+      return { stage: "phase", message: titleCase(progress.phase) };
+  }
+}
+
+/** Formats deterministic reconcile progress for the live feed. */
+function describeReconcileEvent(progress: ReconcileProgress): ProgressLine {
+  const stage = formatReconcileStage(progress.stage);
+  const totalText = `${progress.completed.toLocaleString()}/${progress.total.toLocaleString()} ${progress.unitLabel}`;
+  const details = [`${formatReconcileStatus(progress.status)} ${totalText}`];
+
+  if (typeof progress.previewQueued === "number" && progress.previewQueued > 0) {
+    details.push(`${progress.previewQueued.toLocaleString()} queued for LLM preview`);
+  }
+  if (typeof progress.previewCompleted === "number" && typeof progress.previewTotal === "number" && progress.previewTotal > 0) {
+    details.push(`${progress.previewCompleted.toLocaleString()}/${progress.previewTotal.toLocaleString()} previews completed`);
+  }
+  const totals = summarizeRepairCounts(progress.counts);
+  if (totals.applied > 0 || totals.proposed > 0 || totals.skipped > 0) {
+    details.push(`${totals.applied.toLocaleString()} applied, ${totals.proposed.toLocaleString()} proposed, ${totals.skipped.toLocaleString()} skipped`);
+  }
+
+  return { stage: "reconcile", message: `${stage}: ${details.join("; ")}.` };
+}
+
+/** Formats proposal-resolution progress for the live feed. */
+function describeProposalResolutionEvent(progress: ProposalResolutionProgress): ProgressLine {
+  if (progress.status === "no_work") {
+    return { stage: "proposals", message: "No eligible proposals were ready to resolve." };
+  }
+  if (progress.status === "stalled") {
+    return { stage: "proposals", message: "Proposal resolution stalled before all targeted entries were processed." };
+  }
+
+  const parts = [
+    `${formatProposalStatus(progress.status)} ${progress.processedProposals.toLocaleString()}/${progress.totalProposals.toLocaleString()} proposals`,
+    `${progress.appliedCount.toLocaleString()} applied`,
+    `${progress.rejectedInactiveCount.toLocaleString()} inactive`,
+    `${progress.rejectedInvalidCount.toLocaleString()} invalid`,
+    `${progress.noChangeCount.toLocaleString()} unchanged`,
+  ];
+  if (progress.issueKind) {
+    parts.push(`current issue ${titleCase(progress.issueKind)}`);
+  }
+  if (progress.outcome) {
+    parts.push(`last outcome ${titleCase(progress.outcome)}`);
+  }
+
+  return { stage: "proposals", message: `${parts.join("; ")}.` };
+}
+
+/** Formats a count with singular/plural labels. */
+function formatCount(value: number | undefined, singular: string, plural: string): string {
+  if (typeof value !== "number") {
+    return `an unknown number of ${plural}`;
+  }
+  return `${value.toLocaleString()} ${value === 1 ? singular : plural}`;
+}
+
+/** Formats reconcile stage identifiers for operators. */
+function formatReconcileStage(stage: string): string {
+  switch (stage) {
+    case "health":
+      return "Claim-key health scan";
+    case "invalid_noncanonical":
+      return "Invalid noncanonical keys";
+    case "missing":
+      return "Missing claim keys";
+    case "suspect_canonical":
+      return "Suspect canonical keys";
+    case "entity_family_convergence":
+      return "Entity-family convergence";
+    case "mixed_key_groups":
+      return "Mixed key groups";
+    default:
+      return titleCase(stage);
+  }
+}
+
+/** Formats reconcile lifecycle status identifiers for operators. */
+function formatReconcileStatus(status: string): string {
+  switch (status) {
+    case "snapshot":
+      return "Snapshot";
+    case "started":
+      return "Started";
+    case "preview_progress":
+      return "Previewing";
+    case "progress":
+      return "Processing";
+    case "completed":
+      return "Completed";
+    default:
+      return titleCase(status);
+  }
+}
+
+/** Formats proposal lifecycle status identifiers for operators. */
+function formatProposalStatus(status: string): string {
+  switch (status) {
+    case "started":
+      return "Started";
+    case "proposal_processed":
+      return "Processed";
+    case "completed":
+      return "Completed";
+    default:
+      return titleCase(status);
+  }
+}
+
+/** Summarizes detailed reconcile counters for compact operator logging. */
+function summarizeRepairCounts(counts: ReconcileProgress["counts"]): {
+  applied: number;
+  proposed: number;
+  skipped: number;
+} {
+  return {
+    applied:
+      counts.appliedNormalizations +
+      counts.appliedBackfills +
+      counts.appliedMetadataRewrites +
+      counts.appliedEntityFamilyConvergences,
+    proposed: counts.proposalsEmitted + counts.flaggedAmbiguousProposals,
+    skipped: counts.skippedNoClaim + counts.skippedLowConfidence + counts.skippedCollision,
+  };
 }

--- a/web/src/pages/DreamingPage.tsx
+++ b/web/src/pages/DreamingPage.tsx
@@ -212,6 +212,7 @@ function LiveRun({ job, onFinished }: { job: DreamJobSnapshot; onFinished: () =>
 
   const status = stream.status ?? job.status;
   const isRunning = status === "running" && !stream.finished;
+  const liveDotStatus = isRunning ? "success" : jobStatusVariant(status);
 
   const cancel = async (): Promise<void> => {
     setCancelling(true);
@@ -229,7 +230,7 @@ function LiveRun({ job, onFinished }: { job: DreamJobSnapshot; onFinished: () =>
       <CardHeader
         title={
           <span className="row" style={{ gap: "var(--space-2)" }}>
-            <StatusDot status={jobStatusVariant(status)} pulse={isRunning} />
+            <StatusDot status={liveDotStatus} pulse={isRunning} />
             Live run · {titleCase(job.tier)} {job.apply ? "apply" : "dry-run"}
           </span>
         }
@@ -256,6 +257,7 @@ function LiveRun({ job, onFinished }: { job: DreamJobSnapshot; onFinished: () =>
                 const line = describeEvent(event);
                 return (
                   <div className="log__line" key={event.seq}>
+                    <span className="log__time">{formatLogTime(event.at)}</span>
                     <span className="log__stage">{line.stage}</span>
                     <span className="log__msg">{line.message}</span>
                   </div>
@@ -267,6 +269,15 @@ function LiveRun({ job, onFinished }: { job: DreamJobSnapshot; onFinished: () =>
       </CardBody>
     </Card>
   );
+}
+
+/** Formats a live progress timestamp for the log gutter. */
+function formatLogTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "--:--:--";
+  }
+  return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
 }
 
 /** Drawer showing a persisted run's actions and proposals. */

--- a/web/src/pages/ProposalsPage.tsx
+++ b/web/src/pages/ProposalsPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
 import { ApiError, api } from "../api/client";
-import type { ProposalBacklogItem, ProposalDetail } from "../api/types";
-import { Badge, Button, Card, CardBody, Drawer, EmptyState, Field, Textarea } from "../components/primitives";
+import type { Durable, ProposalBacklogItem, ProposalDetail } from "../api/types";
+import { Badge, Button, Card, CardBody, Drawer, EmptyState, Field, Input, Select, Textarea } from "../components/primitives";
 import { ErrorCard, RequireInstance, Skeleton } from "../components/states";
 import { useToast } from "../components/Toast";
 import { useAsync } from "../hooks/useAsync";
@@ -191,6 +191,7 @@ function ProposalDrawer({ proposalId, onClose, onReviewed }: { proposalId: strin
   };
 
   const proposal = state.data?.proposal;
+  const manualMixedResolution = proposal ? isManualMixedClaimProposal(proposal) : false;
 
   return (
     <Drawer
@@ -213,19 +214,32 @@ function ProposalDrawer({ proposalId, onClose, onReviewed }: { proposalId: strin
 
           <div className="review-brief">
             <span className="section-title">Review decision</span>
-            <p>
-              Decide whether the affected memory should be grouped under the proposed claim key. Apply writes the proposed key after creating a
-              backup. Reject keeps the memory as it is and records why this suggestion should not be used.
-            </p>
-            <ul className="review-checklist">
-              <li>The memory text should be about the proposed topic.</li>
-              <li>The proposed key should describe the stable slot for this memory, not incidental wording.</li>
-              <li>The key should group this memory with the right related memories.</li>
-            </ul>
+            {manualMixedResolution ? (
+              <>
+                <p>This group has conflicting current claim keys and no safe proposed target. Settle the flagged issue with one explicit operator decision.</p>
+                <ul className="review-checklist">
+                  <li>Keep the current keys when the memories are separate slots.</li>
+                  <li>Use one canonical key when the memories belong to the same slot.</li>
+                  <li>Retire selected memories when they are duplicate or wrong.</li>
+                </ul>
+              </>
+            ) : (
+              <>
+                <p>
+                  Decide whether the affected memory should be grouped under the proposed claim key. Apply writes the proposed key after creating a
+                  backup. Reject keeps the memory as it is and records why this suggestion should not be used.
+                </p>
+                <ul className="review-checklist">
+                  <li>The memory text should be about the proposed topic.</li>
+                  <li>The proposed key should describe the stable slot for this memory, not incidental wording.</li>
+                  <li>The key should group this memory with the right related memories.</li>
+                </ul>
+              </>
+            )}
           </div>
 
           <div className="stack" style={{ gap: "var(--space-2)" }}>
-            <span className="section-title">Proposed change</span>
+            <span className="section-title">{manualMixedResolution ? "Flagged keys" : "Proposed change"}</span>
             <ClaimDiff current={proposal.currentClaimKeys} proposed={proposal.proposedClaimKeys} />
           </div>
 
@@ -253,7 +267,9 @@ function ProposalDrawer({ proposalId, onClose, onReviewed }: { proposalId: strin
             ) : null}
           </div>
 
-          {proposal.reviewStatus === "open" ? (
+          {proposal.reviewStatus === "open" && manualMixedResolution ? (
+            <ManualMixedClaimResolution proposalId={proposal.id} durables={state.data.activeDurables} onReviewed={onReviewed} />
+          ) : proposal.reviewStatus === "open" ? (
             <div className="stack" style={{ gap: "var(--space-3)" }}>
               <Field label="Decision reason" hint="Explain why the proposed key should or should not be written.">
                 <Textarea rows={3} value={reason} placeholder="Why is this the right decision for this memory?" onChange={(event) => setReason(event.target.value)} />
@@ -287,4 +303,187 @@ function ProposalDrawer({ proposalId, onClose, onReviewed }: { proposalId: strin
       )}
     </Drawer>
   );
+}
+
+type ManualResolutionChoice = "separate" | "canonical" | "retire";
+
+/** Manual settlement workflow for mixed-key groups without a safe direct target. */
+function ManualMixedClaimResolution({
+  proposalId,
+  durables,
+  onReviewed,
+}: {
+  proposalId: string;
+  durables: Durable[];
+  onReviewed: () => void;
+}): React.ReactElement {
+  const toast = useToast();
+  const uniqueClaimKeys = uniqueStrings(durables.flatMap((durable) => (durable.claim_key ? [durable.claim_key] : [])));
+  const [choice, setChoice] = useState<ManualResolutionChoice>("separate");
+  const [selectedClaimKey, setSelectedClaimKey] = useState(uniqueClaimKeys[0] ?? "__custom");
+  const [customClaimKey, setCustomClaimKey] = useState("");
+  const [selectedRetireIds, setSelectedRetireIds] = useState<string[]>([]);
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const settle = async (): Promise<void> => {
+    const reason = buildManualResolutionReason(choice, note, resolveTargetClaimKey(choice, selectedClaimKey, customClaimKey), selectedRetireIds.length);
+    setBusy(true);
+    try {
+      if (choice === "canonical") {
+        const targetClaimKey = resolveTargetClaimKey(choice, selectedClaimKey, customClaimKey);
+        if (!targetClaimKey) {
+          toast.error("Claim key required", "Choose or enter a canonical claim key.");
+          return;
+        }
+        for (const durable of durables) {
+          if (durable.claim_key !== targetClaimKey) {
+            await api.updateDurable(durable.id, { claimKey: targetClaimKey });
+          }
+        }
+      } else if (choice === "retire") {
+        if (selectedRetireIds.length === 0) {
+          toast.error("Selection required", "Select at least one durable to retire.");
+          return;
+        }
+        for (const durableId of selectedRetireIds) {
+          await api.retireDurable(durableId, reason);
+        }
+      }
+
+      await api.reviewProposal(proposalId, { decision: "reject", reason });
+      toast.success("Issue settled");
+      onReviewed();
+    } catch (error) {
+      toast.error("Resolution failed", error instanceof ApiError ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const toggleRetireId = (durableId: string): void => {
+    setSelectedRetireIds((current) => (current.includes(durableId) ? current.filter((id) => id !== durableId) : [...current, durableId]));
+  };
+
+  const targetClaimKey = resolveTargetClaimKey(choice, selectedClaimKey, customClaimKey);
+
+  return (
+    <div className="manual-resolution">
+      <span className="section-title">Settle flagged issue</span>
+      <div className="manual-resolution__choices">
+        <ResolutionOption
+          active={choice === "separate"}
+          title="Keep separate"
+          body="Close the flag and leave the current claim keys unchanged."
+          onSelect={() => setChoice("separate")}
+        />
+        <ResolutionOption
+          active={choice === "canonical"}
+          title="Use one key"
+          body="Write one trusted manual claim key to every affected durable, then close the flag."
+          onSelect={() => setChoice("canonical")}
+        />
+        <ResolutionOption
+          active={choice === "retire"}
+          title="Retire selected"
+          body="Close duplicate or wrong durables, then close the flag."
+          onSelect={() => setChoice("retire")}
+        />
+      </div>
+
+      {choice === "canonical" ? (
+        <div className="metadata-form__grid">
+          <div className="metadata-form__field metadata-form__field--wide">
+            <Field label="Canonical claim key">
+              <Select value={selectedClaimKey} onChange={(event) => setSelectedClaimKey(event.target.value)}>
+                {uniqueClaimKeys.map((claimKey) => (
+                  <option key={claimKey} value={claimKey}>
+                    {claimKey}
+                  </option>
+                ))}
+                <option value="__custom">Custom key</option>
+              </Select>
+            </Field>
+          </div>
+          {selectedClaimKey === "__custom" ? (
+            <div className="metadata-form__field metadata-form__field--wide">
+              <Field label="Custom key" hint="Canonical entity/attribute format">
+                <Input value={customClaimKey} placeholder="entity/attribute" onChange={(event) => setCustomClaimKey(event.target.value)} />
+              </Field>
+            </div>
+          ) : null}
+          {targetClaimKey ? <span className="hint metadata-form__field--wide">Every active affected durable will use {targetClaimKey}.</span> : null}
+        </div>
+      ) : null}
+
+      {choice === "retire" ? (
+        <div className="manual-resolution__retire-list">
+          {durables.map((durable) => (
+            <label key={durable.id} className="manual-resolution__retire-row">
+              <input type="checkbox" checked={selectedRetireIds.includes(durable.id)} onChange={() => toggleRetireId(durable.id)} />
+              <span className="stack" style={{ gap: 2, minWidth: 0 }}>
+                <strong>{durable.subject}</strong>
+                <span className="mono muted">{durable.claim_key ?? "(no key)"}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      ) : null}
+
+      <Field label="Decision note" hint="Saved on the proposal review record.">
+        <Textarea rows={3} value={note} placeholder="Why does this settle the flagged issue?" onChange={(event) => setNote(event.target.value)} />
+      </Field>
+
+      <div className="row wrap" style={{ gap: "var(--space-3)", justifyContent: "flex-end" }}>
+        <Button variant="primary" icon="check" loading={busy} onClick={() => void settle()}>
+          Settle issue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ResolutionOption({
+  active,
+  title,
+  body,
+  onSelect,
+}: {
+  active: boolean;
+  title: string;
+  body: string;
+  onSelect: () => void;
+}): React.ReactElement {
+  return (
+    <button className={`manual-resolution__option${active ? " is-active" : ""}`} onClick={onSelect}>
+      <strong>{title}</strong>
+      <span>{body}</span>
+    </button>
+  );
+}
+
+function isManualMixedClaimProposal(proposal: ProposalDetail["proposal"]): boolean {
+  return proposal.issueKind === "mixed_claim_key_group" && !proposal.eligibleForApply && proposal.proposedClaimKeys.length === 0;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
+}
+
+function resolveTargetClaimKey(choice: ManualResolutionChoice, selectedClaimKey: string, customClaimKey: string): string {
+  if (choice !== "canonical") {
+    return "";
+  }
+  return selectedClaimKey === "__custom" ? customClaimKey.trim() : selectedClaimKey.trim();
+}
+
+function buildManualResolutionReason(choice: ManualResolutionChoice, note: string, targetClaimKey: string, retireCount: number): string {
+  const suffix = note.trim().length > 0 ? ` Note: ${note.trim()}` : "";
+  if (choice === "canonical") {
+    return `Resolved mixed claim-key group manually by writing canonical key "${targetClaimKey}".${suffix}`;
+  }
+  if (choice === "retire") {
+    return `Resolved mixed claim-key group manually by retiring ${retireCount} duplicate or wrong durable${retireCount === 1 ? "" : "s"}.${suffix}`;
+  }
+  return `Resolved mixed claim-key group manually by keeping the affected durables under separate claim keys.${suffix}`;
 }

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -369,9 +369,18 @@
   background: var(--neutral);
   position: relative;
 }
+.dot::after {
+  content: "";
+  position: absolute;
+  inset: -5px;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+}
 .dot--success {
   background: var(--success);
   --pulse-color: var(--success-soft);
+  --pulse-ring-color: rgba(52, 211, 153, 0.58);
 }
 .dot--warning {
   background: var(--warning);
@@ -386,8 +395,10 @@
 .dot--accent {
   background: var(--accent);
   --pulse-color: var(--accent-glow);
+  --pulse-ring-color: var(--accent-glow);
 }
-.dot--pulse {
+.dot--pulse::after {
+  border: 1px solid var(--pulse-ring-color, var(--pulse-color, var(--accent-glow)));
   animation: pulse-ring 1.8s var(--ease-out) infinite;
 }
 

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -745,6 +745,76 @@
   gap: var(--space-2);
 }
 
+.manual-resolution {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-overlay);
+}
+
+.manual-resolution__choices {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.manual-resolution__option {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-height: 104px;
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.manual-resolution__option:hover,
+.manual-resolution__option.is-active {
+  border-color: var(--accent-dim);
+  background: var(--accent-soft);
+}
+
+.manual-resolution__option strong {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.manual-resolution__option span {
+  font-size: var(--text-xs);
+  line-height: 1.45;
+}
+
+.manual-resolution__retire-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.manual-resolution__retire-row {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.manual-resolution__retire-row strong {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
 @media (max-width: 640px) {
   .metadata-form__grid {
     grid-template-columns: minmax(0, 1fr);
@@ -752,6 +822,10 @@
 
   .metadata-form__actions {
     flex-wrap: wrap;
+  }
+
+  .manual-resolution__choices {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -148,12 +148,18 @@ code,
 
 @keyframes pulse-ring {
   0% {
+    opacity: 0.9;
+    transform: scale(0.72);
     box-shadow: 0 0 0 0 var(--pulse-color, var(--accent-glow));
   }
   70% {
+    opacity: 0;
+    transform: scale(1.8);
     box-shadow: 0 0 0 6px transparent;
   }
   100% {
+    opacity: 0;
+    transform: scale(1.8);
     box-shadow: 0 0 0 0 transparent;
   }
 }

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -476,15 +476,20 @@
 }
 
 .log__line {
-  display: flex;
+  display: grid;
+  grid-template-columns: 82px 100px minmax(0, 1fr);
   gap: var(--space-3);
   animation: fade-in var(--dur) var(--ease);
 }
 
+.log__time {
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
 .log__stage {
   color: var(--accent-bright);
-  flex: none;
-  min-width: 90px;
+  min-width: 0;
 }
 
 .log__msg {


### PR DESCRIPTION
## Summary
- Adds manual mixed-key proposal settlement in the web console and improves live dreaming run SSE feedback.
- Prepares operator flows for alias audit work in the next PR.

## Test plan
- [ ] `pnpm check`
- [ ] Start a dreaming run from the web console and verify live progress updates
- [ ] Exercise mixed-key proposal settlement UI